### PR TITLE
Use SvgBundle for piece sprites

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -156,7 +156,7 @@ fn setup_board(mut commands: Commands) {
     }
 }
 
-/*fn draw_piece_dummy(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn draw_piece_dummy(mut commands: Commands, asset_server: Res<AssetServer>) {
     let svg = asset_server.load("pieces\\a_b.svg");
     commands.spawn_bundle(Svg2dBundle {
         svg,
@@ -166,9 +166,9 @@ fn setup_board(mut commands: Commands) {
     .insert(Piece)
     .insert(Position {x: 4, y: 4})
     .insert(PieceSize::size(0.75));
-}*/
+}
 
-fn draw_piece_dummy(mut commands: Commands, asset_server: Res<AssetServer>) {
+/*fn draw_piece_dummy(mut commands: Commands, asset_server: Res<AssetServer>) {
     for x in 0..8 {
         commands.spawn_bundle(SpriteBundle {
             texture: asset_server.load("pieces\\c_p.png"),
@@ -188,7 +188,7 @@ fn draw_piece_dummy(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     }
  
-}
+}*/
 
 
 


### PR DESCRIPTION
`bevy_svg` adds support for drawing SVGs. 
When drawing pieces using PNGs they display just fine. Of course, SVGs are a bit more complicated:
![image](https://user-images.githubusercontent.com/84604651/170826204-43484169-aea3-483e-b78e-30b83b98f56c.png)

So this will have to be ironed out at some point, if possible.. For the moment, PNGs are fine - just a little bit jaggy.
The inconsistency of sprite placement when using `Origin::Center` has been notified in an existing `bevy_svg` issue: https://github.com/Weasy666/bevy_svg/issues/11#issuecomment-1137574185